### PR TITLE
Setting default ignoretagsregex argument to empty string instead of None

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
     parser.add_argument('-imagestokeep', help='Number of image tags to keep', default='100', action='store',
                         dest='imagestokeep')
     parser.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
-    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default=None, action='store', dest='ignoretagsregex')
+    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="", action='store', dest='ignoretagsregex')
 
     args = parser.parse_args()
     if args.region:


### PR DESCRIPTION
python main.py fails with:
```
Traceback (most recent call last):
  File "main.py", line 211, in <module>
    os.environ["IGNORE_TAGS_REGEX"] = args.ignoretagsregex
  File "/Users/kyle.corupe/.virtualenvs/cloudformtion/bin/../lib/python3.6/os.py", line 674, in __setitem__
    value = self.encodevalue(value)
  File "/Users/kyle.corupe/.virtualenvs/cloudformtion/bin/../lib/python3.6/os.py", line 744, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not NoneType
```

And only works with:
```
python main.py -ignoretagsregex ""
```

Setting default argument value to an empty string instead of None solves this issue.