### PR TITLE
Repositories filter and env variables fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ Deletes the images that are not used by running tasks and which are older than t
 Deletes the images that are not used by running tasks and which are older than the last 20 versions (in foo and bar repositories), in Oregon only, and ignore image tags that contains `release` or `archive`:
 
 `python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -repositories foo bar`
+
+Environment variables can be used instead of arguments:
+
+```
+export REGION=us-west-2
+export DRYRUN=False
+export IMAGES_TO_KEEP=20
+export REPOSITORIES_FILTER='foo bar'
+export IGNORE_TAGS_REGEX='release|archive'
+
+python main.py
+```

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Deletes the images that are not used by running tasks and which are older than t
 
 `python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive`
 
+
+Deletes the images that are not used by running tasks and which are older than the last 20 versions (in foo and bar repositories), in Oregon only, and ignore image tags that contains `release` or `archive`:
+
+`python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -repositories foo bar`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Deletes the images that are not used by running tasks and which are older than t
 
 `python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -repositories foo bar`
 
+Deletes the images that are not used by running tasks and which are older than the last 20 versions (in foo and bar repositories), in Oregon only, select only images with tag begening by `^re` but ignore image tags that contains `release` or `review`:
+
+`python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|review -filtertagsregex ^re -repositories foo bar`
+
 Environment variables can be used instead of arguments:
 
 ```
@@ -75,7 +79,8 @@ export REGION=us-west-2
 export DRYRUN=False
 export IMAGES_TO_KEEP=20
 export REPOSITORIES_FILTER='foo bar'
-export IGNORE_TAGS_REGEX='release|archive'
+export IGNORE_TAGS_REGEX='release|review'
+export FILTER_TAGS_REGEX='^re'
 
 python main.py
 ```

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/main.py
+++ b/main.py
@@ -206,7 +206,7 @@ if __name__ == '__main__':
     parser.add_argument('-region', help='ECR/ECS region', default=os.environ.get('REGION', "None"), action='store', dest='region')
     parser.add_argument('-repositories', help='Filter for repositories names discovery separated by space', default=os.environ.get('REPOSITORIES_FILTER', "").split(),
                          nargs='+', action='store', dest='repositories_filter')
-    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default=os.environ.get('IGNORE_TAGS_REGEX', ""), action='store', dest='ignoretagsregex')
+    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default=os.environ.get('IGNORE_TAGS_REGEX', "^$"), action='store', dest='ignoretagsregex')
     parser.add_argument('-filtertagsregex', help='Regex filter of tag names to limit on images with matching tag', default=os.environ.get('FILTER_TAGS_REGEX', ""), action='store', dest='filtertagsregex')
 
     args = parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -30,7 +30,27 @@ IGNORE_TAGS_REGEX = None
 FILTER_TAGS_REGEX = None
 REPOSITORIES_FILTER = None
 
+def initialize():
+    global REGION
+    global DRYRUN
+    global IMAGES_TO_KEEP
+    global IGNORE_TAGS_REGEX
+    global FILTER_TAGS_REGEX
+    global REPOSITORIES_FILTER
+
+    REGION = os.environ.get('REGION', "None")
+    DRYRUN = os.environ.get('DRYRUN', "false").lower()
+    if DRYRUN == "false":
+        DRYRUN = False
+    else:
+        DRYRUN = True
+    IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
+    IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
+    FILTER_TAGS_REGEX = os.environ.get('FILTER_TAGS_REGEX', "")
+    REPOSITORIES_FILTER = os.environ.get('REPOSITORIES_FILTER', "")
+
 def handler(event, context):
+    initialize()
     if REGION == "None":
         partitions = requests.get("https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json").json()[
                 'partitions']

--- a/main.py
+++ b/main.py
@@ -120,14 +120,18 @@ def discover_delete_images(regionname):
 
         print("Number of running images found {}".format(len(running_sha)))
 
+        image_count = 0
         for image in tagged_images:
-            if tagged_images.index(image) >= int(IMAGES_TO_KEEP):
-                if ignore_tags_image(image,running_sha):
-                    continue
+            print(image['imageDigest'])
+            if ignore_tags_image(image,running_sha):
+                continue
+            if image_count >= int(IMAGES_TO_KEEP):
                 for tag in image['imageTags']:
                     append_to_list(deletesha, image['imageDigest'])
                     append_to_tag_list(deletetag, {"imageUrl": repository['repositoryUri'] + ":" + tag,
-                                                  "pushedAt": image["imagePushedAt"]})
+                                                    "pushedAt": image["imagePushedAt"]})
+            image_count += 1
+
         if deletesha:
             print("Number of images to be deleted: {}".format(len(deletesha)))
             delete_images(


### PR DESCRIPTION
 **main.py: filter on repositories**

    In order to "limitate" the clean, adding a filter on repositories name
    to keep.

It use a list to match repositories name. If the repository is in the list, the repository is used for the clean else it is skipped.

**main.py: fix multiple tags deleting issue**

    When using the -ignoretagsregex, if we had an image with multiple tags
    the image is deleted if all tags not match the ignoretagsregex

    For example image tag: dev foo bar

    -ignoretagsregex dev

    the image will be added to the deletesha list.

    The fix ensure that if one of the images's tags match the
    ignoretagsregex, the image is skiped


**main.py: add python shebang**

In order to be able to chmod +x main.py and use it directly with ./main.py

**main.py: arg to use os.environ**

    Previously environnement variable was defined but always overrided by
    args:

      os.environ["DRYRUN"] = args.dryrun.lower()

    and then affected to the global var:

      DRYRUN = os.environ.get('DRYRUN', "false").lower()

    In this case the real env variables wasn't use.

    This fix allow parser to get by default the env var and them a default
    value. Global var are now using directly args. from parser.


**main.py take care of ignored tag in the keep count**

    Previously the could keep was done on all tagged image but when using
    IGNORE_TAGS_REGEX, the image ignored was taken in the keep count.

    That means if we have 3 images

      * image1 tagfoo
      * image2 tagbar
      * image3 tag bla

    and set keep 1 with ignoretags tagfoo it would have deleted image2 and
    3.

    Now keep is done on other image that are ignored. I the previous example
    it will delete image3 only, ignore image1 (tagfoo) and  keep image2



**main.py: Add filter to clean image with tag match**

    Inspired by https://github.com/awslabs/ecr-cleanup-lambda/pull/17/files

    Add parameter to allow only deleting images where the tag contains a
    specific string

    Specify a regex to match tags. If no tags on the image match, the image
    will be skipped/ignored.

    Allow us to only clean a specifig type/tag of images
