### PR TITLE
Avoid zero-length matches

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def initialize():
     else:
         DRYRUN = True
     IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
-    IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "")
+    IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
 
 def handler(event, context):
     initialize()
@@ -199,7 +199,7 @@ if __name__ == '__main__':
     parser.add_argument('-imagestokeep', help='Number of image tags to keep', default='100', action='store',
                         dest='imagestokeep')
     parser.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
-    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="", action='store', dest='ignoretagsregex')
+    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
 
     args = parser.parse_args()
     if args.region:


### PR DESCRIPTION
With the default value of `""` for the `IGNORE_TAGS_REGEX` we ended up with zero-length matches, which caused many image tags to be ignored as the matching didn't return a `None`.

An example that can demonstrate this behavior is:

```python
import re

REGEX=''
string='something'

response = re.compile(REGEX).match(string)

print("Type: {}".format(type(response)))                         # Type: <type '_sre.SRE_Match'>
print("First position of matching: {}".format(response.start())) # 0
print("Last position of matching: {}".format(response.end()))    # 0

print("---")

REGEX='^$'
string='something'

response = re.compile(REGEX).match(string)

print("Type: {}".format(type(response)))                         # Type: <type 'NoneType'>
```

---

Before this modification we had:

```
Starting with repository :...
Total number of images found: 513
Number of untagged images found 3
Number of running images found 1
Number of images to be deleted: 3
```

And after:

```
Starting with repository :...
Total number of images found: 513
Number of untagged images found 3
Number of running images found 1
Number of images to be deleted: 503
```

Which is more aligned with the expected behavior.