### PR TITLE
Import requests from botocore.vendored if needed

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,10 @@ import os
 import re
 
 import boto3
-import requests
+try:
+    import requests
+except ImportError:
+    from botocore.vendored import requests
 
 REGION = None
 DRYRUN = None


### PR DESCRIPTION
The code runs fine locally but when deployed on AWS Lambda it cannot find 'requests'. By pointing to the one from 'botocore.vendored' it works :)

Closes #25