### PR TITLE
CLI cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from botocore.vendored import requests
 
-REGION = None
+REGION = "ALL"
 DRYRUN = None
 IMAGES_TO_KEEP = None
 IGNORE_TAGS_REGEX = None
@@ -35,8 +35,8 @@ def initialize():
     global IMAGES_TO_KEEP
     global IGNORE_TAGS_REGEX
 
-    REGION = os.environ.get('REGION', "None")
     DRYRUN = os.environ.get('DRYRUN', "false").lower()
+    REGION = os.environ.get("REGION", "ALL")
     if DRYRUN == "false":
         DRYRUN = False
     else:
@@ -47,9 +47,10 @@ def initialize():
 
 def handler(event, context):
     initialize()
-    if REGION == "None":
-        partitions = requests.get("https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json").json()[
-                'partitions']
+    partitions = requests.get(
+        "https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json"
+    ).json()["partitions"]
+    if REGION == "ALL":
         for partition in partitions:
             if partition['partition'] == "aws":
                 for endpoint in partition['services']['ecs']['endpoints']:
@@ -210,7 +211,7 @@ if __name__ == '__main__':
     if args.region:
         os.environ["REGION"] = args.region
     else:
-        os.environ["REGION"] = "None"
+        os.environ["REGION"] = "ALL"
     os.environ["DRYRUN"] = args.dryrun.lower()
     os.environ["IMAGES_TO_KEEP"] = args.imagestokeep
     os.environ["IGNORE_TAGS_REGEX"] = args.ignoretagsregex

--- a/main.py
+++ b/main.py
@@ -24,25 +24,26 @@ except ImportError:
     from botocore.vendored import requests
 
 REGION = "ALL"
-DRYRUN = None
+DRY_RUN = True
 IMAGES_TO_KEEP = None
 IGNORE_TAGS_REGEX = None
 
 
 def initialize():
     global REGION
-    global DRYRUN
+    global DRY_RUN
     global IMAGES_TO_KEEP
     global IGNORE_TAGS_REGEX
 
-    DRYRUN = os.environ.get('DRYRUN', "false").lower()
     REGION = os.environ.get("REGION", "ALL")
-    if DRYRUN == "false":
-        DRYRUN = False
+
+    if os.environ.get("DRY_RUN", "").lower() == "false":
+        DRY_RUN = False
     else:
-        DRYRUN = True
-    IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
-    IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
+        DRY_RUN = True
+
+    IMAGES_TO_KEEP = int(os.environ.get("IMAGES_TO_KEEP", 100))
+    IGNORE_TAGS_REGEX = os.environ.get("IGNORE_TAGS_REGEX", "^$")
 
 
 def handler(event, context):
@@ -177,7 +178,7 @@ def delete_images(ecr_client, deletesha, deletetag, id, name):
         i = 0
         for deletesha_chunk in chunks(deletesha, 100):
             i += 1
-            if not DRYRUN:
+            if not DRY_RUN:
                 delete_response = ecr_client.batch_delete_image(
                     registryId=id,
                     repositoryName=name,
@@ -197,22 +198,49 @@ def delete_images(ecr_client, deletesha, deletetag, id, name):
 
 
 # Below is the test harness
-if __name__ == '__main__':
-    request = {"None": "None"}
-    parser = argparse.ArgumentParser(description='Deletes stale ECR images')
-    parser.add_argument('-dryrun', help='Prints the repository to be deleted without deleting them', default='true',
-                        action='store', dest='dryrun')
-    parser.add_argument('-imagestokeep', help='Number of image tags to keep', default='100', action='store',
-                        dest='imagestokeep')
-    parser.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
-    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Deletes stale ECR images",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # We want the user to explicitly opt-in to deleting images so we'll have a
+    # mutually-exclusive option group which requires running with either
+    # --dry-run or --delete-images
+    delete_mode = parser.add_mutually_exclusive_group(required=True)
+
+    delete_mode.add_argument(
+        "--dry-run",
+        help="Prints the images to be deleted without deleting them",
+        action="store_true",
+        dest="dry_run",
+    )
+    delete_mode.add_argument(
+        "--delete-images",
+        help="Delete the images (cancels --dry-run)",
+        action="store_false",
+        dest="dry_run",
+    )
+
+    parser.add_argument(
+        "--images-to-keep", help="Number of image tags to keep", default=100
+    )
+
+    parser.add_argument(
+        "--region",
+        help="AWS region",
+        default=os.environ.get("AWS_DEFAULT_REGION", "ALL"),
+    )
+
+    parser.add_argument(
+        "--ignore-tags-regex", help="Regex of tag names to ignore", default="^$"
+    )
 
     args = parser.parse_args()
-    if args.region:
-        os.environ["REGION"] = args.region
-    else:
-        os.environ["REGION"] = "ALL"
-    os.environ["DRYRUN"] = args.dryrun.lower()
-    os.environ["IMAGES_TO_KEEP"] = args.imagestokeep
-    os.environ["IGNORE_TAGS_REGEX"] = args.ignoretagsregex
-    handler(request, None)
+
+    os.environ["REGION"] = args.region
+    os.environ["DRY_RUN"] = str(args.dry_run).lower()
+    os.environ["IMAGES_TO_KEEP"] = str(args.images_to_keep)
+    os.environ["IGNORE_TAGS_REGEX"] = args.ignore_tags_regex
+
+    handler({"None": "None"}, None)

--- a/main.py
+++ b/main.py
@@ -152,12 +152,12 @@ def discover_delete_images(regionname):
 
 
 def append_to_list(list, id):
-    if not {'imageDigest': id} in list:
-        list.append({'imageDigest': id})
+    if {"imageDigest": id} not in list:
+        list.append({"imageDigest": id})
 
 
 def append_to_tag_list(list, id):
-    if not id in list:
+    if id not in list:
         list.append(id)
 
 

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import os
 import re
 
 import boto3
+
 try:
     import requests
 except ImportError:
@@ -42,6 +43,7 @@ def initialize():
         DRYRUN = True
     IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
     IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
+
 
 def handler(event, context):
     initialize()


### PR DESCRIPTION
I was testing this locally and made several changes to make the process a bit nicer. Beyond some PEP-8 cleanup, here are the major changes:

* Use the AWS_DEFAULT_REGION environmental variable as the region if defined
* Use a mutually-exclusive option group so CLI users must explicitly select either a dry-run or deleting images
* The output is now more consistently formatted and has a nicer display of the image IDs which would be deleted