### PR TITLE
Fixes error that happens when attempting to reach a disabled region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ s3transfer-0.1.8.dist-info
 six-1.10.0.dist-info
 __pycache__
 s3transfer-0.1.9.dist-info
-requests
 botocore-1.4.68.dist-info
 docutils-0.12.dist-info
-requests-2.11.1.dist-info
 .idea

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def initialize():
     IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
     IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
 
-def handler():
+def handler(event, context):
     initialize()
     if REGION == "None":
         ec2_client = boto3.client('ec2')

--- a/main.py
+++ b/main.py
@@ -15,12 +15,7 @@ from __future__ import print_function
 import argparse
 import os
 import re
-
 import boto3
-try:
-    import requests
-except ImportError:
-    from botocore.vendored import requests
 
 REGION = None
 DRYRUN = None
@@ -43,15 +38,13 @@ def initialize():
     IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
     IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
 
-def handler(event, context):
+def handler():
     initialize()
     if REGION == "None":
-        partitions = requests.get("https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json").json()[
-                'partitions']
-        for partition in partitions:
-            if partition['partition'] == "aws":
-                for endpoint in partition['services']['ecs']['endpoints']:
-                    discover_delete_images(endpoint)
+        ec2_client = boto3.client('ec2')
+        available_regions = ec2_client.describe_regions()['Regions']
+        for region in available_regions:
+            discover_delete_images(region['RegionName'])
     else:
         discover_delete_images(REGION)
 
@@ -65,8 +58,6 @@ def discover_delete_images(regionname):
     for response_listrepopaginator in describe_repo_paginator.paginate():
         for repo in response_listrepopaginator['repositories']:
             repositories.append(repo)
-
-    # print(repositories)
 
     ecs_client = boto3.client('ecs', region_name=regionname)
 
@@ -129,15 +120,15 @@ def discover_delete_images(regionname):
                             running_sha.append(image['imageDigest'])
 
         print("Number of running images found {}".format(len(running_sha)))
-
+        ignore_tags_regex = re.compile(IGNORE_TAGS_REGEX)
         for image in tagged_images:
             if tagged_images.index(image) >= IMAGES_TO_KEEP:
                 for tag in image['imageTags']:
-                    if "latest" not in tag and re.compile(IGNORE_TAGS_REGEX).search(tag) is None:
+                    if "latest" not in tag and ignore_tags_regex.search(tag) is None:
                         if not running_sha or image['imageDigest'] not in running_sha:
                             append_to_list(deletesha, image['imageDigest'])
                             append_to_tag_list(deletetag, {"imageUrl": repository['repositoryUri'] + ":" + tag,
-                                                        "pushedAt": image["imagePushedAt"]})
+                                                           "pushedAt": image["imagePushedAt"]})
         if deletesha:
             print("Number of images to be deleted: {}".format(len(deletesha)))
             delete_images(
@@ -151,23 +142,23 @@ def discover_delete_images(regionname):
             print("Nothing to delete in repository : " + repository['repositoryName'])
 
 
-def append_to_list(list, id):
-    if not {'imageDigest': id} in list:
-        list.append({'imageDigest': id})
+def append_to_list(image_digest_list, repo_id):
+    if not {'imageDigest': repo_id} in image_digest_list:
+        image_digest_list.append({'imageDigest': repo_id})
 
 
-def append_to_tag_list(list, id):
-    if not id in list:
-        list.append(id)
+def append_to_tag_list(tag_list, tag_id):
+    if not tag_id in tag_list:
+        tag_list.append(tag_id)
 
 
-def chunks(l, n):
+def chunks(repo_list, chunk_size):
     """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+    for i in range(0, len(repo_list), chunk_size):
+        yield repo_list[i:i + chunk_size]
 
 
-def delete_images(ecr_client, deletesha, deletetag, id, name):
+def delete_images(ecr_client, deletesha, deletetag, repo_id, name):
     if len(deletesha) >= 1:
         ## spliting list of images to delete on chunks with 100 images each
         ## http://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_BatchDeleteImage.html#API_BatchDeleteImage_RequestSyntax
@@ -176,13 +167,13 @@ def delete_images(ecr_client, deletesha, deletetag, id, name):
             i += 1
             if not DRYRUN:
                 delete_response = ecr_client.batch_delete_image(
-                    registryId=id,
+                    registryId=repo_id,
                     repositoryName=name,
                     imageIds=deletesha_chunk
                 )
                 print(delete_response)
             else:
-                print("registryId:" + id)
+                print("registryId:" + repo_id)
                 print("repositoryName:" + name)
                 print("Deleting {} chank of images".format(i))
                 print("imageIds:", end='')
@@ -195,21 +186,21 @@ def delete_images(ecr_client, deletesha, deletetag, id, name):
 
 # Below is the test harness
 if __name__ == '__main__':
-    request = {"None": "None"}
-    parser = argparse.ArgumentParser(description='Deletes stale ECR images')
-    parser.add_argument('-dryrun', help='Prints the repository to be deleted without deleting them', default='true',
+    REQUEST = {"None": "None"}
+    PARSER = argparse.ArgumentParser(description='Deletes stale ECR images')
+    PARSER.add_argument('-dryrun', help='Prints the repository to be deleted without deleting them', default='true',
                         action='store', dest='dryrun')
-    parser.add_argument('-imagestokeep', help='Number of image tags to keep', default='100', action='store',
+    PARSER.add_argument('-imagestokeep', help='Number of image tags to keep', default='100', action='store',
                         dest='imagestokeep')
-    parser.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
-    parser.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
+    PARSER.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
+    PARSER.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
 
-    args = parser.parse_args()
-    if args.region:
-        os.environ["REGION"] = args.region
+    ARGS = PARSER.parse_args()
+    if ARGS.region:
+        os.environ["REGION"] = ARGS.region
     else:
         os.environ["REGION"] = "None"
-    os.environ["DRYRUN"] = args.dryrun.lower()
-    os.environ["IMAGES_TO_KEEP"] = args.imagestokeep
-    os.environ["IGNORE_TAGS_REGEX"] = args.ignoretagsregex
-    handler(request, None)
+    os.environ["DRYRUN"] = ARGS.dryrun.lower()
+    os.environ["IMAGES_TO_KEEP"] = ARGS.imagestokeep
+    os.environ["IGNORE_TAGS_REGEX"] = ARGS.ignoretagsregex
+    handler(REQUEST, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 boto3
-requests


### PR DESCRIPTION
Amazon recently introduced a region, ap-east-1, which is disabled by default. The lambda started throwing ClientToken errors when it tried to access this region. This change gets a list of regions which are available and enabled by calling 'describe_regions' on a boto ec2 client. Please note that this change may require the lambda to be given ec2:DescribeRegions IAM permissions.

This removes the dependency on the 'requests' library. The gitignore and requirements.txt have been updated accordingly.

There is also a second commit that just makes some linting improvements based on Pylint's recommendations, and refactors a regex compile to be outside of a for loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
