### PR TITLE
Added a new flag for strictly ignoring images that have tags matching…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,12 @@ Deletes the images that are not used by running tasks and which are older than t
 
 Deletes the images that are not used by running tasks and which are older than the last 20 versions (in each repository), in Oregon only, and ignore image tags that contains `release` or `archive`:
 
+**WARNING**: If an image has multiple tags and one of it tag is matched for ignore but the rest are not, then the image would still be deleted. Consider using *-strictIgnore* if you are looking for a more strict ignore behavior. 
+
 `python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive`
 
+Strictly skip an image if one of its tags matched the regex defined in -ignoretagsregex. E.g. if image ABC is tagged with *release_123* and *master_123* and -ignoretagsregex is *release_*, then image ABC will not be marked for deletion.
+
+**NOTE**: This flag has no affect if used without *-ignoretagsregex*  
+
+`python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -strictIgnore true`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Deletes the images that are not used by running tasks and which are older than t
 
 Deletes the images that are not used by running tasks and which are older than the last 20 versions (in each repository), in Oregon only, and ignore image tags that contains `release` or `archive`:
 
-**WARNING**: If an image has multiple tags and one of it tag is matched for ignore but the rest are not, then the image would still be deleted. Consider using *-strictIgnore* if you are looking for a more strict ignore behavior. 
+**WARNING**: If an image has multiple tags and one of it tag is matched for ignore but the rest are not, then the image would still be deleted. Consider using *-strictignore* if you are looking for a more strict ignore behavior. 
 
 `python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive`
 
@@ -69,4 +69,4 @@ Strictly skip an image if one of its tags matched the regex defined in -ignoreta
 
 **NOTE**: This flag has no affect if used without *-ignoretagsregex*  
 
-`python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -strictIgnore true`
+`python main.py –dryrun False –imagestokeep 20 –region us-west-2 -ignoretagsregex release|archive -strictignore true`

--- a/main.py
+++ b/main.py
@@ -21,13 +21,14 @@ REGION = None
 DRYRUN = None
 IMAGES_TO_KEEP = None
 IGNORE_TAGS_REGEX = None
-
+STRICT_IGNORE = None
 
 def initialize():
     global REGION
     global DRYRUN
     global IMAGES_TO_KEEP
     global IGNORE_TAGS_REGEX
+    global STRICT_IGNORE
 
     REGION = os.environ.get('REGION', "None")
     DRYRUN = os.environ.get('DRYRUN', "false").lower()
@@ -37,6 +38,11 @@ def initialize():
         DRYRUN = True
     IMAGES_TO_KEEP = int(os.environ.get('IMAGES_TO_KEEP', 100))
     IGNORE_TAGS_REGEX = os.environ.get('IGNORE_TAGS_REGEX', "^$")
+    STRICT_IGNORE = os.environ.get('STRICT_IGNORE', "false").lower()
+    if STRICT_IGNORE == "false":
+        STRICT_IGNORE = False
+    else:
+        STRICT_IGNORE = True
 
 def handler(event, context):
     initialize()
@@ -123,6 +129,17 @@ def discover_delete_images(regionname):
         ignore_tags_regex = re.compile(IGNORE_TAGS_REGEX)
         for image in tagged_images:
             if tagged_images.index(image) >= IMAGES_TO_KEEP:
+                # if strict mode is set, check if at least 1 image matches the regex. Skip image if true
+                if STRICT_IGNORE is True:
+                    ignore_regex_matched = False 
+                    for tag in image['imageTags']:
+                        if ignore_tags_regex.search(tag) is not None:
+                            print("Image to skip because of strict mode: ", image)
+                            ignore_regex_matched = True
+                            break
+                    if ignore_regex_matched is True:
+                        break
+
                 for tag in image['imageTags']:
                     if "latest" not in tag and ignore_tags_regex.search(tag) is None:
                         if not running_sha or image['imageDigest'] not in running_sha:
@@ -194,6 +211,9 @@ if __name__ == '__main__':
                         dest='imagestokeep')
     PARSER.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
     PARSER.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
+    PARSER.add_argument('-strictIgnore', 
+                        help='Strictly ignore an image if any tag for this image matched the regex defined in ignoretagsregex option', 
+                        default="false", action='store', dest='strictIgnore')
 
     ARGS = PARSER.parse_args()
     if ARGS.region:
@@ -203,4 +223,5 @@ if __name__ == '__main__':
     os.environ["DRYRUN"] = ARGS.dryrun.lower()
     os.environ["IMAGES_TO_KEEP"] = ARGS.imagestokeep
     os.environ["IGNORE_TAGS_REGEX"] = ARGS.ignoretagsregex
+    os.environ["STRICT_IGNORE"] = ARGS.strictIgnore
     handler(REQUEST, None)

--- a/main.py
+++ b/main.py
@@ -211,9 +211,9 @@ if __name__ == '__main__':
                         dest='imagestokeep')
     PARSER.add_argument('-region', help='ECR/ECS region', default=None, action='store', dest='region')
     PARSER.add_argument('-ignoretagsregex', help='Regex of tag names to ignore', default="^$", action='store', dest='ignoretagsregex')
-    PARSER.add_argument('-strictIgnore', 
+    PARSER.add_argument('-strictignore', 
                         help='Strictly ignore an image if any tag for this image matched the regex defined in ignoretagsregex option', 
-                        default="false", action='store', dest='strictIgnore')
+                        default="false", action='store', dest='strictignore')
 
     ARGS = PARSER.parse_args()
     if ARGS.region:
@@ -223,5 +223,5 @@ if __name__ == '__main__':
     os.environ["DRYRUN"] = ARGS.dryrun.lower()
     os.environ["IMAGES_TO_KEEP"] = ARGS.imagestokeep
     os.environ["IGNORE_TAGS_REGEX"] = ARGS.ignoretagsregex
-    os.environ["STRICT_IGNORE"] = ARGS.strictIgnore
+    os.environ["STRICT_IGNORE"] = ARGS.strictignore
     handler(REQUEST, None)


### PR DESCRIPTION
… -ignoretagsregex flag.

PR for fixing issue: https://github.com/awslabs/ecr-cleanup-lambda/issues/34

This PR aims to provide an additional flag fo strictly ignoring images that matched the regex defined in _-ignoretagsregex_. Without this, images with tags that did not all match the regex will still be deleted. See the issue link for more details. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
