### PR TITLE
Correct backticks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install virtualenv:
 
 1. CD to the folder that contains main.py.
 1. Run the following command:
-`pip install -r requirements.txt -t `pwd``
+``pip install -r requirements.txt -t `pwd` ``
 1. Compress the contents of folder (not the folder).
     
 ## Upload the package to Lambda


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating the pip install command in the "Generate the Lambda package" step in README.md so the backticks can show properly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
